### PR TITLE
[BE] 스프링으로 전환하기 #9

### DIFF
--- a/src/main/java/spring/core/AppConfig.java
+++ b/src/main/java/spring/core/AppConfig.java
@@ -1,5 +1,8 @@
 package spring.core;
 
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
 import spring.core.discount.DiscountPolicy;
 import spring.core.discount.FixDiscountPolicy;
 import spring.core.member.MemberService;
@@ -8,20 +11,26 @@ import spring.core.member.MemoryMemberRepository;
 import spring.core.order.OrderService;
 import spring.core.order.OrderServiceImpl;
 
+@Configuration
 public class AppConfig {
 
+	// 스프링 컨테이너에 스프링 빈으로 등록하는 과정
+	@Bean
 	public MemberService memberService() {
 		return new MemberServiceImpl(memberRepository());
 	}
 
-	private MemoryMemberRepository memberRepository() {
+	@Bean
+	public MemoryMemberRepository memberRepository() {
 		return new MemoryMemberRepository();
 	}
 
+	@Bean
 	public OrderService orderService() {
 		return new OrderServiceImpl(memberRepository(), discountPolicy());
 	}
 
+	@Bean
 	public DiscountPolicy discountPolicy() {
 		return new FixDiscountPolicy();
 	}

--- a/src/main/java/spring/core/MemberApp.java
+++ b/src/main/java/spring/core/MemberApp.java
@@ -1,5 +1,8 @@
 package spring.core;
 
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
 import spring.core.member.Grade;
 import spring.core.member.Member;
 import spring.core.member.MemberService;
@@ -7,8 +10,14 @@ import spring.core.member.MemberService;
 public class MemberApp {
 
 	public static void main(String[] args) {
-		AppConfig appConfig = new AppConfig();
-		MemberService memberService = appConfig.memberService();
+		// AppConfig appConfig = new AppConfig();
+		// MemberService memberService = appConfig.memberService();
+
+		// ApplicationContext 를 스프링 컨테이너라고 한다.
+		ApplicationContext applicationContext = new AnnotationConfigApplicationContext(AppConfig.class);
+		// 스프링 컨테이너를 통해 필요한 스프링 빈(객체)을 찾아야 한다.
+		MemberService memberService = applicationContext.getBean("memberService", MemberService.class);
+
 		Member member = new Member(1L, "memberA", Grade.VIP);
 		memberService.join(member);
 

--- a/src/main/java/spring/core/OrderApp.java
+++ b/src/main/java/spring/core/OrderApp.java
@@ -1,5 +1,8 @@
 package spring.core;
 
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
 import spring.core.member.Grade;
 import spring.core.member.Member;
 import spring.core.member.MemberService;
@@ -9,9 +12,13 @@ import spring.core.order.OrderService;
 public class OrderApp {
 
 	public static void main(String[] args) {
-		AppConfig appConfig = new AppConfig();
-		MemberService memberService = appConfig.memberService();
-		OrderService orderService = appConfig.orderService();
+		// AppConfig appConfig = new AppConfig();
+		// MemberService memberService = appConfig.memberService();
+		// OrderService orderService = appConfig.orderService();
+
+		ApplicationContext applicationContext = new AnnotationConfigApplicationContext(AppConfig.class);
+		OrderService orderService = applicationContext.getBean("orderService", OrderService.class);
+		MemberService memberService = applicationContext.getBean("memberService", MemberService.class);
 
 		long memberId = 1L;
 		Member member = new Member(memberId, "memberA", Grade.VIP);

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,12 @@
+<configuration>
+    `
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} -%kvp-
+                %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="DEBUG">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
스프링으로 전환하기
지금까지 순수한 자바 코드만으로 DI를 적용했다. 이제 스프링을 사용해보자.
지금은 코드만 작성하고 설명은 마지막에 하겠다.

1. **AppConfig 스프링 기반으로 변경**
  - AppConfig에 설정을 구성한다는 뜻의 `@Configuration` 을 붙여준다.
  - 각 메서드에 `@Bean` 을 붙여준다.
  - => 스프링 컨테이너에 스프링 빈 등록

2. MemberApp, OrderApp에  스프링 컨테이너 적용
```java
// OrderApp
ApplicationContext applicationContext = new AnnotationConfigApplicationContext(AppConfig.class);
MemberService memberService = applicationContext.getBean("memberService", MemberService.class);
OrderService orderService = applicationContext.getBean("orderService", OrderService.class);
```

3. spring container
 - `ApplicationContext` 를 스프링 컨테이너라 한다.
 - 기존에는 개발자가 `AppConfig` 를 사용해서 직접 객체를 생성하고 DI를 했지만, 이제부터는 스프링 컨테이너를 통해서 사용한다.
 - 스프링 컨테이너는 `@Configuration` 이 붙은 `AppConfig` 를 설정(구성) 정보로 사용한다. 여기서 `@Bean` 이라 적힌 메서드를 모두 호출해서 반환된 객체를 스프링 컨테이너에 등록한다. 이렇게 스프링 컨테이너에 등록된 객체를 스프링 빈이라 한다.
 - 스프링 빈은 `@Bean` 이 붙은 메서드의 명을 스프링 빈의 이름으로 사용한다. (`memberService` ,`orderService` )
 - 이전에는 개발자가 필요한 객체를 `AppConfig` 를 사용해서 직접 조회했지만, 이제부터는 스프링 컨테이너를 통해서 필요한 스프링 빈(객체)를 찾아야 한다. 스프링 빈은 `applicationContext.getBean()` 메서드를 사용해서 찾을 수 있다.
 - 기존에는 개발자가 직접 자바코드로 모든 것을 했다면 이제부터는 스프링 컨테이너에 객체를 스프링 빈으로 등록하고, 스프링 컨테이너에서 스프링 빈을 찾아서 사용하도록 변경되었다.